### PR TITLE
Add highlighting of DOM elements for views

### DIFF
--- a/js/backboneAgent/backboneAgent.js
+++ b/js/backboneAgent/backboneAgent.js
@@ -43,11 +43,16 @@ Modules.set('backboneAgent', function() {
         },
 
         // PUBLIC API
+
         isBackboneDetected: false,
+
+        appComponentsInfos: appComponentsInfos,
+
         server: server,
         database: Modules.get('database'),
         Reader: Modules.get('Reader'),
-        appComponentsInfos: appComponentsInfos,
+
+        appComponentControllers: appComponentControllers
 
     }))();
 

--- a/js/backboneAgent/controllers/appViewController.js
+++ b/js/backboneAgent/controllers/appViewController.js
@@ -8,8 +8,9 @@ Modules.set('controllers.appViewController', function() {
 
     var appViewController = new (AppComponentController.extend({ // singleton
 
-        // the currently highlighted DOM element
-        highlightedElement: undefined,
+        // the DOM element that is placed hover another element to highlight it,
+        // is created just-in-time when needed.
+        highlightMask: undefined,
 
         handle: function(view) {
             // on new instance
@@ -169,7 +170,7 @@ Modules.set('controllers.appViewController', function() {
             highlightMask.style.pointerEvents = 'none';
             highlightMask.style.backgroundColor = 'rgba(55, 161, 243, 0.48)';
             highlightMask.style.webkitFilter = 'grayscale(20%)';
-            
+
             // set position and size (top, right, bottom, left, width, height)
             var bounds = element.getBoundingClientRect();
             u.each(bounds, function(boundValue, boundName) {

--- a/js/backboneAgent/controllers/appViewController.js
+++ b/js/backboneAgent/controllers/appViewController.js
@@ -9,12 +9,11 @@ Modules.set('controllers.appViewController', function() {
 
     var appViewController = new (AppComponentController.extend({ // singleton
 
-        // the DOM element that is placed hover another element to highlight it,
-        // is created just-in-time when needed.
+        // the DOM element that is placed hover another element to highlight it
         highlightMask: undefined,
 
         initialize: function() {
-            this.setupHighlightMask();
+            this.setupHighlight();
         },
 
         handle: function(view) {
@@ -162,7 +161,14 @@ Modules.set('controllers.appViewController', function() {
             }});
         },
 
-        setupHighlightMask: function() {
+        setupHighlight: function() {
+            this.highlightMask = document.createElement('div');
+            this.highlightMask.style.position = 'absolute';
+            this.highlightMask.style.zIndex = '100000000000';
+            this.highlightMask.style.pointerEvents = 'none';
+            this.highlightMask.style.backgroundColor = 'rgba(55, 161, 243, 0.48)';
+            this.highlightMask.style.webkitFilter = 'grayscale(20%)';
+
             // unhighlight when the user closes the devtools, etc.
             this.listenTo(port, 'client:disconnect', this.unhighlightViewElements);
         },
@@ -174,28 +180,25 @@ Modules.set('controllers.appViewController', function() {
             var element = view.$el ? view.$el[0] : view.el;
             if (!element) return;
 
-            var highlightMask = document.createElement('div');
-            highlightMask.style.position = 'absolute';
-            highlightMask.style.zIndex = '100000000000';
-            highlightMask.style.pointerEvents = 'none';
-            highlightMask.style.backgroundColor = 'rgba(55, 161, 243, 0.48)';
-            highlightMask.style.webkitFilter = 'grayscale(20%)';
-
             // set position and size (top, right, bottom, left, width, height)
             var bounds = element.getBoundingClientRect();
             u.each(bounds, function(boundValue, boundName) {
-                highlightMask.style[boundName] = boundValue+'px';
+                this.highlightMask.style[boundName] = boundValue+'px';
             }, this);
 
-            document.body.appendChild(highlightMask);
+            if (!this.highlightMask.parentNode) {
+                // is not in the dom yet
+                document.body.appendChild(this.highlightMask);
+            }
 
-            this.highlightMask = highlightMask;
+            // make visible
+            this.highlightMask.style.display = '';
         },
 
         unhighlightViewElements: function() {
-            if (this.highlightMask) {
-                this.highlightMask.parentNode.removeChild(this.highlightMask);
-                this.highlightMask = undefined;
+            // hide if visible
+            if (this.highlightMask.style.display != 'none') {
+                this.highlightMask.style.display = 'none';
             }
         }
 

--- a/js/backboneAgent/controllers/appViewController.js
+++ b/js/backboneAgent/controllers/appViewController.js
@@ -157,17 +157,34 @@ Modules.set('controllers.appViewController', function() {
         },
 
         // highlight the dom element associated with the view
-        highlight: function(view) {
-            this.unhighlight();
+        highlightViewElement: function(view) {
+            this.unhighlightViewElements();
 
-            view.$el.css('box-shadow', '0px 0px 20px #f00');
-            this.highlightedElement = view.$el;
+            var element = view.$el ? view.$el[0] : view.el;
+            if (!element) return;
+
+            var highlightMask = document.createElement('div');
+            highlightMask.style.position = 'absolute';
+            highlightMask.style.zIndex = '100000000000';
+            highlightMask.style.pointerEvents = 'none';
+            highlightMask.style.backgroundColor = 'rgba(55, 161, 243, 0.48)';
+            highlightMask.style.webkitFilter = 'grayscale(20%)';
+            
+            // set position and size (top, right, bottom, left, width, height)
+            var bounds = element.getBoundingClientRect();
+            u.each(bounds, function(boundValue, boundName) {
+                highlightMask.style[boundName] = boundValue+'px';
+            }, this);
+
+            document.body.appendChild(highlightMask);
+
+            this.highlightMask = highlightMask;
         },
 
-        unhighlight: function() {
-            if (this.highlightedElement) {
-                this.highlightedElement.css('box-shadow', '');
-                this.highlightedElement = undefined;
+        unhighlightViewElements: function() {
+            if (this.highlightMask) {
+                this.highlightMask.parentNode.removeChild(this.highlightMask);
+                this.highlightMask = undefined;
             }
         }
 

--- a/js/backboneAgent/controllers/appViewController.js
+++ b/js/backboneAgent/controllers/appViewController.js
@@ -8,6 +8,9 @@ Modules.set('controllers.appViewController', function() {
 
     var appViewController = new (AppComponentController.extend({ // singleton
 
+        // the currently highlighted DOM element
+        highlightedElement: undefined,
+
         handle: function(view) {
             // on new instance
 
@@ -151,6 +154,22 @@ Modules.set('controllers.appViewController', function() {
 
                 return result;
             }});
+        },
+
+        // highlight the dom element associated with the view
+        highlight: function(view) {
+            this.unhighlight();
+
+            view.$el.css('box-shadow', '0px 0px 20px #f00');
+            this.highlightedElement = view.$el;
+        },
+
+        // remove the highlight
+        unhighlight: function() {
+            if (this.highlightedElement) {
+                this.highlightedElement.css('box-shadow', '');
+                this.highlightedElement = undefined;
+            }
         }
 
     }))();

--- a/js/backboneAgent/controllers/appViewController.js
+++ b/js/backboneAgent/controllers/appViewController.js
@@ -2,6 +2,7 @@ Modules.set('controllers.appViewController', function() {
     // imports
     var AppComponentController = Modules.get('controllers.AppComponentController');
     var u = Modules.get('utils');
+    var port = Modules.get('port');
     var appViewsInfo = Modules.get('collections.appViewsInfo');
     var appModelsInfo = Modules.get('collections.appModelsInfo');
     var appCollectionsInfo = Modules.get('collections.appCollectionsInfo');
@@ -11,6 +12,10 @@ Modules.set('controllers.appViewController', function() {
         // the DOM element that is placed hover another element to highlight it,
         // is created just-in-time when needed.
         highlightMask: undefined,
+
+        initialize: function() {
+            this.setupHighlightMask();
+        },
 
         handle: function(view) {
             // on new instance
@@ -155,6 +160,11 @@ Modules.set('controllers.appViewController', function() {
 
                 return result;
             }});
+        },
+
+        setupHighlightMask: function() {
+            // unhighlight when the user closes the devtools, etc.
+            this.listenTo(port, 'client:disconnect', this.unhighlightViewElements);
         },
 
         // highlight the dom element associated with the view

--- a/js/backboneAgent/controllers/appViewController.js
+++ b/js/backboneAgent/controllers/appViewController.js
@@ -164,7 +164,6 @@ Modules.set('controllers.appViewController', function() {
             this.highlightedElement = view.$el;
         },
 
-        // remove the highlight
         unhighlight: function() {
             if (this.highlightedElement) {
                 this.highlightedElement.css('box-shadow', '');

--- a/js/backboneAgent/index.json
+++ b/js/backboneAgent/index.json
@@ -8,6 +8,8 @@
 
         "Component.js",
 
+        "port.js",
+
         "hidden.js",
 
         "models/Model.js",

--- a/js/backboneAgent/port.js
+++ b/js/backboneAgent/port.js
@@ -1,0 +1,42 @@
+Modules.set('port', function() {
+	// imports
+	var Component = Modules.get('Component');
+	var u = Modules.get('utils');
+
+	var port = new (Component.extend({ // singleton
+
+		initialize: function() {
+			this.startListening();
+		},
+
+		startListening: function() {
+			window.addEventListener('message', u.bind(function(event) {
+			    // Only accept messages from same frame
+			    if (event.source != window) return;
+
+			    var message = event.data;
+
+			    // Only accept our messages
+			    if (!u.isObject(message) || message.target != 'extension') return;
+
+			    this.trigger(message.name, message);
+			}, this));
+		},
+
+		// Note: messageName is prefixed by "backboneAgent:" and can't contain spaces
+		// (because might be transformed in a Backbone event in the Panel)
+		sendMessage: function(messageName, messageData) {
+		    messageName = 'backboneAgent:'+messageName;
+
+		    window.postMessage({
+		        target: 'page',
+		        timestamp: new Date().getTime(),
+		        name: messageName,
+		        data: messageData
+		    }, '*');
+		}
+
+	}))();
+
+	return port;
+});

--- a/js/panel/collections/appViews.js
+++ b/js/panel/collections/appViews.js
@@ -10,7 +10,7 @@ function(Backbone, _, AppComponents, AppView, backboneAgentClient) {
 
         unhighlightViewElements: function() {
         	backboneAgentClient.execFunction(function() {
-        	    this.appComponentControllers['View'].unhighlight();
+        	    this.appComponentControllers['View'].unhighlightViewElements();
         	});
         }
 

--- a/js/panel/collections/appViews.js
+++ b/js/panel/collections/appViews.js
@@ -1,11 +1,18 @@
-define(["backbone", "underscore", "collections/AppComponents", "models/AppView"],
-function(Backbone, _, AppComponents, AppView) {
+define(["backbone", "underscore", "collections/AppComponents", "models/AppView", 
+		"backboneAgentClient"],
+function(Backbone, _, AppComponents, AppView, backboneAgentClient) {
 
     var appViews = new (AppComponents.extend({
 
         componentCategory: "View",
         model: AppView,
-        url: '/views'
+        url: '/views',
+
+        unhighlightViewElements: function() {
+        	backboneAgentClient.execFunction(function() {
+        	    this.appComponentControllers['View'].unhighlight();
+        	});
+        }
 
     }))();
     return appViews;

--- a/js/panel/models/AppView.js
+++ b/js/panel/models/AppView.js
@@ -22,7 +22,7 @@ function(Backbone, _, AppComponent, backboneAgentClient) {
         highlightElement: function() {
             backboneAgentClient.execFunction(function(componentIndex) {
                 var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
-                this.appComponentControllers['View'].highlight(appViewInfo.component);
+                this.appComponentControllers['View'].highlightViewElement(appViewInfo.component);
             }, [this.index]);
         }
 

--- a/js/panel/models/AppView.js
+++ b/js/panel/models/AppView.js
@@ -16,21 +16,21 @@ function(Backbone, _, AppComponent, backboneAgentClient) {
                 var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
                 var appViewEl = appViewInfo.component.el;
                 console.log(appViewEl);
-            }, [this.index], function(){});
+            }, [this.index]);
         },
 
         highlightElement: function() {
             backboneAgentClient.execFunction(function(componentIndex) {
                 var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
                 appViewInfo.component.$el.css('box-shadow', '0px 0px 20px #f00');
-            }, [this.index], function(){});
+            }, [this.index]);
         },
 
         unHighlightElement: function() {
             backboneAgentClient.execFunction(function(componentIndex) {
                 var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
                 appViewInfo.component.$el.css('box-shadow', '');
-            }, [this.index], function(){});
+            }, [this.index]);
         }
 
     });

--- a/js/panel/models/AppView.js
+++ b/js/panel/models/AppView.js
@@ -16,9 +16,21 @@ function(Backbone, _, AppComponent, backboneAgentClient) {
                 var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
                 var appViewEl = appViewInfo.component.el;
                 console.log(appViewEl);
-            }, [this.index], _.bind(function(result) { // on executed
-                // do nothing
-            }, this));
+            }, [this.index], function(){});
+        },
+
+        highlightElement: function() {
+            backboneAgentClient.execFunction(function(componentIndex) {
+                var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
+                appViewInfo.component.$el.css('box-shadow', '0px 0px 20px #f00');
+            }, [this.index], function(){});
+        },
+
+        unHighlightElement: function() {
+            backboneAgentClient.execFunction(function(componentIndex) {
+                var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
+                appViewInfo.component.$el.css('box-shadow', '');
+            }, [this.index], function(){});
         }
 
     });

--- a/js/panel/models/AppView.js
+++ b/js/panel/models/AppView.js
@@ -24,12 +24,6 @@ function(Backbone, _, AppComponent, backboneAgentClient) {
                 var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
                 this.appComponentControllers['View'].highlight(appViewInfo.component);
             }, [this.index]);
-        },
-
-        unHighlightElement: function() {
-            backboneAgentClient.execFunction(function(componentIndex) {
-                this.appComponentControllers['View'].unhighlight();
-            }, [this.index]);
         }
 
     });

--- a/js/panel/models/AppView.js
+++ b/js/panel/models/AppView.js
@@ -22,14 +22,13 @@ function(Backbone, _, AppComponent, backboneAgentClient) {
         highlightElement: function() {
             backboneAgentClient.execFunction(function(componentIndex) {
                 var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
-                appViewInfo.component.$el.css('box-shadow', '0px 0px 20px #f00');
+                this.appComponentControllers['View'].highlight(appViewInfo.component);
             }, [this.index]);
         },
 
         unHighlightElement: function() {
             backboneAgentClient.execFunction(function(componentIndex) {
-                var appViewInfo = this.appComponentsInfos['View'].at(componentIndex);
-                appViewInfo.component.$el.css('box-shadow', '');
+                this.appComponentControllers['View'].unhighlight();
             }, [this.index]);
         }
 

--- a/js/panel/views/AppComponentActionView.js
+++ b/js/panel/views/AppComponentActionView.js
@@ -9,7 +9,7 @@ function(Backbone, _, $, View, Handlebars, template) {
         tagName: "tr",
 
         initialize: function(options) {
-            _.bindAll(this);
+            View.prototype.initialize.apply(this, arguments);
 
             this.listenTo(this.model, "change", this.render);
 

--- a/js/panel/views/AppComponentView.js
+++ b/js/panel/views/AppComponentView.js
@@ -11,7 +11,7 @@ function(Backbone, _, $, View, AppComponentActionsView) {
         appComponentActionsView: undefined, // AppComponentActionsView for the component actions
 
         initialize: function(options) {
-            _.bindAll(this);
+            View.prototype.initialize.apply(this, arguments);
 
             // create sub-view for the component actions
             this.appComponentActionsView = new AppComponentActionsView({

--- a/js/panel/views/AppViewView.js
+++ b/js/panel/views/AppViewView.js
@@ -8,29 +8,32 @@ function(Backbone, _, $, AppComponentView, Handlebars, template) {
 
         template: Handlebars.compile(template),
 
+        render: function() {
+            AppComponentView.prototype.render.apply(this, arguments);
+            
+            // TODO: unbind below elements on view remove to prevent memory leaks
+            // (though as for now the components are never removed)
+            var appComponent = this.$('.appComponent');
+            appComponent.on('hidden', _.bind(function(event) { // fired just after the hide animation ends
+                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
+                    this.unHighlightDOMElementUnlessOpened()
+                }
+            }, this));
+            appComponent.on('show', _.bind(function(event) { // fired just before the show animation starts
+                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
+                    this.highlightDOMElement()
+                }
+            }, this));
+
+            return this;
+        },
+
         events: $.extend({
             "click .printElement": "printElement"
         }, AppComponentView.prototype.events),
 
         printElement: function() {
             this.model.printElement();
-        },
-
-        render: function() {
-            AppViewView.__super__.render.apply(this, arguments); // Call superclass render
-            var self = this;
-            var appComponent = this.$('.appComponent');
-
-            appComponent.on('hidden', function(event) { // fired just after the hide animation ends
-                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
-                    self.unHighlightDOMElementUnlessOpened()
-                }
-            });
-            appComponent.on('show', function(event) { // fired just before the show animation starts
-                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
-                    self.highlightDOMElement()
-                }
-            });
         },
 
         highlightDOMElement: function() {

--- a/js/panel/views/AppViewView.js
+++ b/js/panel/views/AppViewView.js
@@ -14,6 +14,33 @@ function(Backbone, _, $, AppComponentView, Handlebars, template) {
 
         printElement: function() {
             this.model.printElement();
+        },
+
+        render: function() {
+            AppViewView.__super__.render.apply(this, arguments); // Call superclass render
+            var self = this;
+            var appComponent = this.$('.appComponent');
+
+            appComponent.on('hidden', function(event) { // fired just after the hide animation ends
+                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
+                    self.unHighlightDOMElementUnlessOpened()
+                }
+            });
+            appComponent.on('show', function(event) { // fired just before the show animation starts
+                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
+                    self.highlightDOMElement()
+                }
+            });
+        },
+
+        highlightDOMElement: function() {
+            this.model.highlightElement();
+        },
+
+        unHighlightDOMElementUnlessOpened: function() {
+            if (!this.isOpened()) {
+                this.model.unHighlightElement();
+            }
         }
 
     });

--- a/js/panel/views/AppViewView.js
+++ b/js/panel/views/AppViewView.js
@@ -8,26 +8,6 @@ function(Backbone, _, $, AppComponentView, Handlebars, template) {
 
         template: Handlebars.compile(template),
 
-        render: function() {
-            AppComponentView.prototype.render.apply(this, arguments);
-            
-            // TODO: unbind below elements on view remove to prevent memory leaks
-            // (though as for now the components are never removed)
-            var appComponent = this.$('.appComponent');
-            appComponent.on('hidden', _.bind(function(event) { // fired just after the hide animation ends
-                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
-                    this.unHighlightDOMElementUnlessOpened()
-                }
-            }, this));
-            appComponent.on('show', _.bind(function(event) { // fired just before the show animation starts
-                if ($(event.target).is(appComponent)) { // don't handle if fired by child collapsable elements
-                    this.highlightDOMElement()
-                }
-            }, this));
-
-            return this;
-        },
-
         events: $.extend({
             "click .printElement": "printElement"
         }, AppComponentView.prototype.events),
@@ -36,14 +16,8 @@ function(Backbone, _, $, AppComponentView, Handlebars, template) {
             this.model.printElement();
         },
 
-        highlightDOMElement: function() {
+        highlightElement: function() {
             this.model.highlightElement();
-        },
-
-        unHighlightDOMElementUnlessOpened: function() {
-            if (!this.isOpened()) {
-                this.model.unHighlightElement();
-            }
         }
 
     });

--- a/js/panel/views/View.js
+++ b/js/panel/views/View.js
@@ -4,6 +4,8 @@ define(["backbone", "underscore", "jquery"], function(Backbone, _, $) {
 
         initialize: function(options) {
             _.bindAll(this);
+
+            this.domListeners = [];
         },
 
         // true to show, false to hide
@@ -14,6 +16,48 @@ define(["backbone", "underscore", "jquery"], function(Backbone, _, $) {
         isShown: function() {
             // might be true also if the parent is hidden, differently from jquery ".is(':visible')"
             return this.$el.css('display') != 'none';
+        },
+
+        // A wrapper for $el.on(eventName, handler) that adds garbage management:
+        // the event is unbinded automatically on view remove; the user can
+        // also remove it manually by passing the returned index to stopDOMListening.
+        // It is useful for binding events to elements like $(window), $(document)
+        // and generally everything that is outside the Backbone.View events hash.
+        // Note: the handler is automatically bound to the view.
+        listenToDOM: function($el, eventName, handler) {
+            handler = _.bind(handler, this);
+
+            $el.on(eventName, handler);
+            var domListener = [$el, eventName, handler];
+            var domListenerIndex = this.domListeners.length;
+            this.domListeners.push(domListener);
+            return domListenerIndex;
+        },
+
+        stopDOMListening: function(domListenerIndex) {
+            var domListener = this.domListeners[domListenerIndex];
+            if (!domListener) return;
+
+            var $el = domListener[0],
+                eventName = domListener[1],
+                handler = domListener[2];
+
+            $el.off(eventName, handler);
+
+            delete this.domListeners[domListenerIndex];
+        },
+
+        clearDOMListeners: function() {
+            for (var i=0,l=this.domListeners.length; i<l; i++) {
+                this.stopDOMListening(i);
+            }
+            this.domListeners = [];
+        },
+
+        remove: function() {
+            this.clearDOMListeners();
+
+            Backbone.View.prototype.remove.apply(this, arguments);
         }
 
     });

--- a/js/panel/views/containers/AppViewsView.js
+++ b/js/panel/views/containers/AppViewsView.js
@@ -9,7 +9,7 @@ function(Backbone, _, $, AppComponentsView, appViews, AppViewView) {
 
         events: function() {
             return $.extend({
-                "mouseenter .appComponentList>li": "highlightViewElement",
+                "mouseover .appComponentList>li": "highlightViewElement",
                 "mouseleave .appComponentList>li": "unhighlightViewElements"
             }, AppComponentsView.prototype.events.apply(this, arguments));
         },

--- a/js/panel/views/containers/AppViewsView.js
+++ b/js/panel/views/containers/AppViewsView.js
@@ -7,6 +7,14 @@ function(Backbone, _, $, AppComponentsView, appViews, AppViewView) {
         collection: appViews,
         CollectionItemView: AppViewView,
 
+        initialize: function() {
+            AppComponentsView.prototype.initialize.apply(this, arguments);
+
+            // unhighlight when mouse goes outside the panel window
+            // TODO: improve this if possible, the mouse leave is not always detected.
+            this.listenToDOM($(document), "mouseleave", this.unhighlightViewElements);
+        },
+
         events: function() {
             return $.extend({
                 "mouseover .appComponentList>li": "highlightViewElement",

--- a/js/panel/views/containers/AppViewsView.js
+++ b/js/panel/views/containers/AppViewsView.js
@@ -5,7 +5,24 @@ function(Backbone, _, $, AppComponentsView, appViews, AppViewView) {
     var AppViewsView = AppComponentsView.extend({
 
         collection: appViews,
-        CollectionItemView: AppViewView
+        CollectionItemView: AppViewView,
+
+        events: function() {
+            return $.extend({
+                "mouseenter .appComponentToggle": "highlightDOMElement",
+                "mouseleave .appComponentToggle": "unHighlightDOMElementUnlessOpened"
+            }, AppComponentsView.prototype.events.apply(this, arguments));
+        },
+
+        highlightDOMElement: function(e) {
+          var componentIndex = Number.parseInt(e.target.dataset.componentIndex);
+          this.getComponentView(componentIndex).highlightDOMElement();
+        },
+
+        unHighlightDOMElementUnlessOpened: function(e) {
+          var componentIndex = Number.parseInt(e.target.dataset.componentIndex);
+          this.getComponentView(componentIndex).unHighlightDOMElementUnlessOpened();
+        }
 
     });
     return AppViewsView;

--- a/js/panel/views/containers/AppViewsView.js
+++ b/js/panel/views/containers/AppViewsView.js
@@ -9,21 +9,19 @@ function(Backbone, _, $, AppComponentsView, appViews, AppViewView) {
 
         events: function() {
             return $.extend({
-                "mouseenter .appComponentToggle": "highlightDOMElement",
-                "mouseleave .appComponentToggle": "unHighlightDOMElementUnlessOpened"
+                "mouseenter .appComponentList>li": "highlightViewElement",
+                "mouseleave .appComponentList>li": "unhighlightViewElements"
             }, AppComponentsView.prototype.events.apply(this, arguments));
         },
 
-        highlightDOMElement: function(event) {
-            var target = $(event.target);
-            var componentIndex = parseInt(target.attr("data-component-index"), 10);
-            this.getComponentView(componentIndex).highlightDOMElement();
+        highlightViewElement: function(event) {
+            var appComponentToggle = $(event.currentTarget).find('.appComponentToggle');
+            var componentIndex = parseInt(appComponentToggle.attr("data-component-index"), 10);
+            this.getComponentView(componentIndex).highlightElement();
         },
 
-        unHighlightDOMElementUnlessOpened: function(event) {
-            var target = $(event.target);
-            var componentIndex = parseInt(target.attr("data-component-index"), 10);
-            this.getComponentView(componentIndex).unHighlightDOMElementUnlessOpened();
+        unhighlightViewElements: function() {
+            this.collection.unhighlightViewElements();
         }
 
     });

--- a/js/panel/views/containers/AppViewsView.js
+++ b/js/panel/views/containers/AppViewsView.js
@@ -14,14 +14,16 @@ function(Backbone, _, $, AppComponentsView, appViews, AppViewView) {
             }, AppComponentsView.prototype.events.apply(this, arguments));
         },
 
-        highlightDOMElement: function(e) {
-          var componentIndex = Number.parseInt(e.target.dataset.componentIndex);
-          this.getComponentView(componentIndex).highlightDOMElement();
+        highlightDOMElement: function(event) {
+            var target = $(event.target);
+            var componentIndex = parseInt(target.attr("data-component-index"), 10);
+            this.getComponentView(componentIndex).highlightDOMElement();
         },
 
-        unHighlightDOMElementUnlessOpened: function(e) {
-          var componentIndex = Number.parseInt(e.target.dataset.componentIndex);
-          this.getComponentView(componentIndex).unHighlightDOMElementUnlessOpened();
+        unHighlightDOMElementUnlessOpened: function(event) {
+            var target = $(event.target);
+            var componentIndex = parseInt(target.attr("data-component-index"), 10);
+            this.getComponentView(componentIndex).unHighlightDOMElementUnlessOpened();
         }
 
     });

--- a/js/panel/views/containers/CollectionView.js
+++ b/js/panel/views/containers/CollectionView.js
@@ -34,7 +34,7 @@ function(Backbone, _, $, View, Handlebars, SearchFilter, setImmediate) {
         },
 
         initialize: function(options) {
-            _.bindAll(this);
+            View.prototype.initialize.apply(this, arguments);
 
             // array con una vista per ogni item
             this.collectionItemViews = [];

--- a/js/panel/views/main/DebugDisabledView.js
+++ b/js/panel/views/main/DebugDisabledView.js
@@ -8,7 +8,7 @@ function(Backbone, _, $, View, Handlebars, template) {
         template: Handlebars.compile(template),
 
         initialize: function(options) {
-            _.bindAll(this);
+            View.prototype.initialize.apply(this, arguments);
 
             this.render();
         },

--- a/js/panel/views/main/DebuggerView.js
+++ b/js/panel/views/main/DebuggerView.js
@@ -20,7 +20,7 @@ function(Backbone, _, $, View, Handlebars, template,
         tabViews: {}, // hash <tabId, tabView> where tabView is of type tabTypes[tabId]
 
         initialize: function(options) {
-            _.bindAll(this);
+            View.prototype.initialize.apply(this, arguments);
 
             this.render();
 

--- a/js/panel/views/main/WaitingView.js
+++ b/js/panel/views/main/WaitingView.js
@@ -11,9 +11,9 @@ function(Backbone, _, $, View, Handlebars, template) {
         waitingText: undefined,
 
         initialize: function(options) {
-            options = options || {};
+            View.prototype.initialize.apply(this, arguments);
 
-            _.bindAll(this);
+            options = options || {};
 
             this.setWaitingText(options.waitingText || '');
             // (first render provided by above function)

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Backbone Debugger",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Developer Tools extension for debugging Backbone.js applications.",
   "author": "Manuel Dell'Elce and contributors",
   "minimum_chrome_version": "22.0",

--- a/templates/appView.html
+++ b/templates/appView.html
@@ -1,6 +1,7 @@
 <a class="appComponentToggle btn btn-link {{#compare component_status 'Removed'}}removed{{/compare}}"
    data-toggle="collapse" 
-   data-target="#view{{index}}">
+   data-target="#view{{index}}"
+   data-component-index="{{index}}">
    <span>View {{index}} {{#unlessNull component_name}} : {{component_name}} {{/unlessNull}}</span>
 </a>
 

--- a/updated.html
+++ b/updated.html
@@ -29,20 +29,13 @@
 		<div id="wrap"><div class="container">
 			<div class="page-header">
 				<h2><a title="Backbone Debugger on Chrome Web Store" href="https://chrome.google.com/webstore/detail/backbone-debugger/bhljhndlimiafopmmhjlgfpnnchjjbhd">Backbone Debugger</a>
-					has been successfully updated to v0.2.5!</h2>
+					has been successfully updated to v0.3.0!</h2>
 			</div>
 
 			<p class="lead">
 			Changes from last version:
 			<ul>
-				<li>Added instant <b>free text search</b> for filtering components and actions, with real time update in case components change.</li>
-			   	<li>Use view selectors (e.g. li.done) as <b>view names</b> in panel, with real time update.</li>
-				<li>New components navigation style.</li>
-				<li>Break long words in panel to prevent overflow in case of long names, long urls, etc.</li>
-				<li>Bugfix: Fix WatchJS bug (<a href="https://github.com/Maluen/Backbone-Debugger/issues/14">#14</a>).</li>
-				<li>Bugfix: Make hidden properties really hidden (<a href="https://github.com/Maluen/Backbone-Debugger/issues/16">#16</a>).</li>
-				<li>Optimization: better handling of backbone agent reports.</li>
-				<li>Only show the view index in the Elements sidebar pane.</li>
+				<li>Added highlighting of view DOM elements when hovered or toggled open in the debugger.</li>
 			</ul>
 			</p>
 


### PR DESCRIPTION
#### What's this PR do?
This adds highlighting of a views `el` DOM element when hovered over or toggled open in the Backbone Debugger view pane.

Currently this just adds and a removes a red CSS box shadow for the highlighting, but I'm completely open to other effects.

I've also included a version bump to `v0.3.0`, as this contains new functionality, but is the same in terms of its user interface.

#### Where should the reviewer start?
The changes made are fairly simple, the only part I'd consider a quite ugly code is using the DOM to store data on the index of the corresponding view element (used in `AppViewsView.js`). Otherwise, it's just adding a couple of new methods and event listeners to achieve the behaviour. If there's a better way for me to achieve this without refactoring the whole project let me know, this code is quite unfamiliar to me.

#### How should this be manually tested?
Open up the debugger on your favourite Backbone app, and use the "Views" tab. You'll notice as you hover over the view links and open/close them, that the corresponding dom element is highlighted in red.

#### Any background context you want to provide?
I work on a large backbone app with a couple of hundred views, it's sometimes very difficult to figure out what view corresponds to which DOM element on the page, my hope is this will help to ease that pain for my team and other Backbone developers.

#### Screenshots:

![screen shot 2014-12-28 at 14 53 01](https://cloud.githubusercontent.com/assets/1911741/5564107/43c28f5e-8ea1-11e4-85b1-53c162a2c82f.png)
