### PR TITLE
Handle case where backbone is set to undefined

### DIFF
--- a/js/backboneAgent/controllers/backboneController.js
+++ b/js/backboneAgent/controllers/backboneController.js
@@ -17,7 +17,11 @@ Modules.set('controllers.backboneController', function() {
             this.callback = callback;
 
             // global
-            u.onSetted(window, "Backbone", u.bind(this.handleBackbone, this));
+            u.onSetted(window, "Backbone", u.bind(function (backbone) {
+                if (backbone) {
+                    this.handleBackbone(backbone);
+                }
+            }, this));
 
             // AMD
             var me = this;


### PR DESCRIPTION
Debugging an app that uses requirejs, and also uses the global `window.Backbone`. Eventually `window.Backbone` is set to `undefined`, which causes an exception at [utils.js line 140](https://github.com/jbreeden/Backbone-Debugger/blob/handle_undefined_backbone/js/backboneAgent/utils.js#L141) when trying to read a property off of undefined.

Just adding a quick check for this case.