### PR TITLE
Window.postmessage() corrections

### DIFF
--- a/js/backboneAgent/port.js
+++ b/js/backboneAgent/port.js
@@ -51,7 +51,7 @@ Modules.set('port', function() {
 				target: 'page',
 				timestamp: new Date().getTime(),
 				name: 'connect'
-			}, [this.channel.port2], '*');
+			}, '*', [this.channel.port2]);
 
 			this.isConnectedWithExtension = true;
 		},

--- a/js/contentscript.js
+++ b/js/contentscript.js
@@ -76,7 +76,7 @@ var contentScript = new (function() { // singleton
 			target: 'extension',
 			timestamp: new Date().getTime(),
 			name: 'connect'
-		}, [this.channel.port2], '*');
+		}, '*', [this.channel.port2]);
 
 		this.isConnectedWithPage = true;
 	};


### PR DESCRIPTION
Chrome had incorrectly implemented an overload of window.postmessage(), where it allowed the optional [transfer] parameter to precede the targetOrigin. [That overloaded version of the method is being removed](https://www.chromestatus.com/feature/5719033043222528
).